### PR TITLE
Manifest generation captures consul security flags

### DIFF
--- a/manifest-generation/config-from-cf-internal.yml
+++ b/manifest-generation/config-from-cf-internal.yml
@@ -8,6 +8,13 @@ config_from_cf:
     staging_upload_password: (( properties.cc.staging_upload_password ))
   consul:
     lan_servers: (( properties.consul.agent.servers.lan ))
+    ca_cert: (( properties.consul.ca_cert ))
+    agent_cert: (( properties.consul.agent_cert ))
+    agent_key: (( properties.consul.agent_key ))
+    encrypt_key: (( properties.consul.encrypt_key ))
+    require_ssl: (( properties.consul.require_ssl ))
+    server_cert: (( properties.consul.server_cert ))
+    server_key: (( properties.consul.server_key ))
   system_domain: (( properties.system_domain ))
 
 # The keys below should not be included in the final stub
@@ -22,4 +29,11 @@ properties:
     agent:
       servers:
         lan: (( merge ))
+    ca_cert:
+    agent_cert:
+    agent_key:
+    encrypt_key:
+    require_ssl:
+    server_cert:
+    server_key:
   system_domain: (( merge ))

--- a/manifest-generation/config-from-cf.yml
+++ b/manifest-generation/config-from-cf.yml
@@ -8,4 +8,11 @@ config_from_cf:
     staging_upload_password: (( merge ))
   consul:
     lan_servers: (( merge ))
+    ca_cert: (( merge ))
+    agent_cert: (( merge ))
+    agent_key: (( merge ))
+    encrypt_key: (( merge ))
+    require_ssl: (( merge ))
+    server_cert: (( merge ))
+    server_key: (( merge ))
   system_domain: (( merge ))

--- a/manifest-generation/docker-cache.yml
+++ b/manifest-generation/docker-cache.yml
@@ -49,6 +49,13 @@ properties:
     agent:
       servers:
         lan: (( config_from_cf.consul.lan_servers ))
+    ca_cert: (( config_from_cf.consul.ca_cert ))
+    agent_cert: (( config_from_cf.consul.agent_cert ))
+    agent_key: (( config_from_cf.consul.agent_key ))
+    encrypt_key: (( config_from_cf.consul.encrypt_key ))
+    require_ssl: (( config_from_cf.consul.require_ssl ))
+    server_cert: (( config_from_cf.consul.server_cert ))
+    server_key: (( config_from_cf.consul.server_key ))
   docker_registry:
     storage:
       name: (( property_overrides.docker_registry.storage.name || "filesystem" ))


### PR DESCRIPTION
This is analogous to the following diego-release commits:
- https://github.com/cloudfoundry-incubator/diego-release/commit/8b0ce6c5d66e95266157ad320d20606d76aff91a
- https://github.com/cloudfoundry-incubator/diego-release/commit/e6116a233ac11b20bc6298af2c87aef72b0f3d59
