### PR TITLE
Fix consul job properties, add OpenStack iaas-settings

### DIFF
--- a/manifest-generation/config-from-cf-internal.yml
+++ b/manifest-generation/config-from-cf-internal.yml
@@ -7,6 +7,7 @@ config_from_cf:
     staging_upload_user: (( properties.cc.staging_upload_user ))
     staging_upload_password: (( properties.cc.staging_upload_password ))
   consul:
+    domain: (( properties.consul.agent.domain ))
     lan_servers: (( properties.consul.agent.servers.lan ))
     ca_cert: (( properties.consul.ca_cert ))
     agent_cert: (( properties.consul.agent_cert ))
@@ -29,6 +30,7 @@ properties:
     staging_upload_password: (( merge ))
   consul:
     agent:
+      domain: (( merge ))
       servers:
         lan: (( merge ))
     ca_cert:

--- a/manifest-generation/config-from-cf.yml
+++ b/manifest-generation/config-from-cf.yml
@@ -7,6 +7,7 @@ config_from_cf:
     staging_upload_user: (( merge ))
     staging_upload_password: (( merge ))
   consul:
+    domain: (( merge ))
     lan_servers: (( merge ))
     ca_cert: (( merge ))
     agent_cert: (( merge ))

--- a/manifest-generation/docker-cache.yml
+++ b/manifest-generation/docker-cache.yml
@@ -49,6 +49,7 @@ properties:
   # -- Property below is used by the consul_agent job from cf-release --
   consul:
     agent:
+      domain: (( config_from_cf.consul.domain ))
       servers:
         lan: (( config_from_cf.consul.lan_servers ))
     ca_cert: (( config_from_cf.consul.ca_cert ))

--- a/manifest-generation/examples/openstack/iaas-settings.yml
+++ b/manifest-generation/examples/openstack/iaas-settings.yml
@@ -14,7 +14,7 @@ iaas_settings:
       subnets:
       - range: 10.0.1.0/24
         gateway: 10.0.1.1
-        static: []
+        reserved: []
         cloud_properties:
           net_id: DIEGO_1_NET_ID
           security_groups:

--- a/manifest-generation/examples/openstack/iaas-settings.yml
+++ b/manifest-generation/examples/openstack/iaas-settings.yml
@@ -1,0 +1,22 @@
+iaas_settings:
+  stemcell:
+    name: bosh-openstack-kvm-ubuntu-trusty-go_agent
+    version: latest
+  compilation_cloud_properties:
+    instance_type: m1.small
+  resource_pool_cloud_properties:
+    - name: docker-cache
+      cloud_properties:
+        instance_type: m1.medium
+  subnet_configs:
+    - name: docker-cache
+      type: manual
+      subnets:
+      - range: 10.0.1.0/24
+        gateway: 10.0.1.1
+        static: []
+        cloud_properties:
+          net_id: DIEGO_1_NET_ID
+          security_groups:
+          - bosh
+          - cf-private


### PR DESCRIPTION
Hi!

Starting from cf-release v234 consul require `consul.agent.domain` property, i update stubs to grab this property from CF deploy manifest. Here the [link](https://www.pivotaltracker.com/n/projects/1488988/stories/114803375) to appropriate fix in cf-release.

Also i add example iaas-settings stub from diego-release to simplify deployment on OpenStack IAAS. Iaas-setting have reserved property in networks block instead of static to deploy diego-docker-cache in same subnet where Diego-release located.
